### PR TITLE
Update Maven docs with current maven version

### DIFF
--- a/docs/maven/upgrade_maven.md
+++ b/docs/maven/upgrade_maven.md
@@ -1,14 +1,14 @@
 # Upgrade Maven in Ubuntu
 
-    wget https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz
+    wget https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz
     sudo mkdir -p /usr/local/apache-maven
-    sudo mv apache-maven-3.8.6-bin.tar.gz /usr/local/apache-maven
+    sudo mv apache-maven-3.9.0-bin.tar.gz /usr/local/apache-maven
     cd /usr/local/apache-maven
-    sudo tar -xzvf apache-maven-3.8.6-bin.tar.gz 
+    sudo tar -xzvf apache-maven-3.9.0-bin.tar.gz 
 
 Edit `~/.profile` with `sudo vi ~/.profile` and add these four lines:   
 
-    export M2_HOME=/usr/local/apache-maven/apache-maven-3.8.6
+    export M2_HOME=/usr/local/apache-maven/apache-maven-3.9.0
     export M2=$M2_HOME/bin
     export MAVEN_OPTS="-Xms256m -Xmx512m"
     export PATH=$M2:$PATH          


### PR DESCRIPTION
Old download link broke (CDN only contains last patch of each minor version); this updates to newest `3.9.0`.